### PR TITLE
removed hardcoded batch from add/remove associate

### DIFF
--- a/client-side/src/app/portals/Bam/components/calendar/add-associate-to-batch/add-associate-to-batch.component.ts
+++ b/client-side/src/app/portals/Bam/components/calendar/add-associate-to-batch/add-associate-to-batch.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { BamUser } from '../../../models/bamuser.model';
 import { UsersService } from '../../../services/users.service';
+import { Batch } from '../../../models/batch.model';
+import { SessionService } from '../../../services/session.service';
 
 @Component({
   selector: 'app-add-associate-to-batch',
@@ -15,12 +17,13 @@ import { UsersService } from '../../../services/users.service';
  *
  */
 export class AddAssociateToBatchComponent implements OnInit {
+  currentBatch: Batch;
 
   associates: BamUser[];
   @Input() searchTerm: string;
-  @Output() notify: EventEmitter<any> = new EventEmitter<any>(); 
+  @Output() notify: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(private usersService: UsersService) {
+  constructor(private usersService: UsersService, private sessionService: SessionService) {
   }
 
   ngOnInit() {
@@ -34,13 +37,14 @@ export class AddAssociateToBatchComponent implements OnInit {
    */
   addUser(user: BamUser) {
     let i = 0;
+    this.currentBatch = this.sessionService.getSelectedBatch();
     for (let associate of this.associates) {
       if (associate.userId === user.userId) {
-        this.usersService.addUserToBatch(4, associate.userId).subscribe(users => {
+        this.usersService.addUserToBatch(this.currentBatch.id, associate.userId).subscribe(users => {
           this.associates = users;
-          this.associateAlert("success", `Successfully added ${user.fName} ${user.lName} to current batch.`);
+          this.associateAlert('success', `Successfully added ${user.fName} ${user.lName} to current batch.`);
         }, error => {
-          this.associateAlert("danger", `Error: couldn't add ${user.fName} ${user.lName} to current batch.`);
+          this.associateAlert('danger', `Error: couldn't add ${user.fName} ${user.lName} to current batch.`);
         });
         break;
       }

--- a/client-side/src/app/portals/Bam/components/calendar/add-associate-to-batch/add-associate-to-batch.component.ts
+++ b/client-side/src/app/portals/Bam/components/calendar/add-associate-to-batch/add-associate-to-batch.component.ts
@@ -14,6 +14,7 @@ import { SessionService } from '../../../services/session.service';
  * Class for adding an associate to the batch.
  * @author Patrick Kennedy | Batch: 1712-Steve
  * @author Shane Avery Sistoza | Batch: 1712-Steve
+ * @author Jeffery Camacho | Batch: 1712-Steve
  *
  */
 export class AddAssociateToBatchComponent implements OnInit {

--- a/client-side/src/app/portals/Bam/components/calendar/remove-associate-from-batch/remove-associate-from-batch.component.ts
+++ b/client-side/src/app/portals/Bam/components/calendar/remove-associate-from-batch/remove-associate-from-batch.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { BamUser } from '../../../models/bamuser.model';
 import { UsersService } from '../../../services/users.service';
+import { Batch } from '../../../models/batch.model';
+import { SessionService } from '../../../services/session.service';
 
 @Component({
   selector: 'app-remove-associate-from-batch',
@@ -15,18 +17,20 @@ import { UsersService } from '../../../services/users.service';
  * @batch 1712-Steve
  */
 export class RemoveAssociateFromBatchComponent implements OnInit {
+  currentBatch: Batch;
 
   associates: BamUser[];
   @Input() searchTerm: string;
   @Input() associateAlertType: string;
   @Input() associateAlertMessage: string;
-  @Output() notify: EventEmitter<any> = new EventEmitter<any>(); 
+  @Output() notify: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(public usersService: UsersService) {
+  constructor(public usersService: UsersService, private sessionService: SessionService) {
   }
 
   ngOnInit() {
-    this.usersService.getUsersInBatch(4).subscribe(users => this.associates = users);
+    this.currentBatch = this.sessionService.getSelectedBatch();
+    this.usersService.getUsersInBatch(this.currentBatch.id).subscribe(users => this.associates = users);
   }
 
   /**
@@ -40,10 +44,10 @@ export class RemoveAssociateFromBatchComponent implements OnInit {
       if (associate.userId === user.userId) {
         this.usersService.removeUserFromBatch(associate.userId).subscribe(users => {
           this.associates = users;
-          this.associateAlert("success", `Successfully removed ${user.fName} ${user.lName} from current batch.`);
+          this.associateAlert('success', `Successfully removed ${user.fName} ${user.lName} from current batch.`);
         }, error => {
-          this.associateAlert("danger", `Error: couldn't remove ${user.fName} ${user.lName} from current batch.`);
-        }); 
+          this.associateAlert('danger', `Error: couldn't remove ${user.fName} ${user.lName} from current batch.`);
+        });
         break;
       }
       i++;

--- a/client-side/src/app/portals/Bam/components/calendar/view-associates/view-associates.component.ts
+++ b/client-side/src/app/portals/Bam/components/calendar/view-associates/view-associates.component.ts
@@ -37,7 +37,7 @@ export class ViewAssociatesComponent implements OnInit {
    * Gets the trainers associate in the batch
    */
   loadAssociates() {
-    this.currentBatch = JSON.parse(sessionStorage.getItem('batch'));
+    this.currentBatch = this.sessionService.getSelectedBatch();
     if (this.currentBatch != null) {
       this.usersService.getUsersInBatch(this.currentBatch.id).subscribe(data => {
         console.log(data);


### PR DESCRIPTION
Add and Remove user from the calendar view had a hardcoded batch. Now components have batch that is stored in the session. View associate also changed to use that service to pull the current batch from premade service rather than parsing the incoming JSON from the service.