### PR TITLE
Created simple utility service

### DIFF
--- a/client-side/src/app/portals/Caliber/screening/services/UrlUtil/url-util.service.spec.ts
+++ b/client-side/src/app/portals/Caliber/screening/services/UrlUtil/url-util.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { UrlUtilService } from './url-util.service';
+
+describe('UrlUtilService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [UrlUtilService]
+    });
+  });
+
+  it('should be created', inject([UrlUtilService], (service: UrlUtilService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/client-side/src/app/portals/Caliber/screening/services/UrlUtil/url-util.service.ts
+++ b/client-side/src/app/portals/Caliber/screening/services/UrlUtil/url-util.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class UrlUtilService {
+
+  // base url to get to the zuul gateway
+  readonly zuulEndpoint = "https://hydra-gateway-service.cfapps.io";
+
+  constructor() { }
+
+  public getBase(): string {
+    return this.zuulEndpoint;
+  }
+
+
+}


### PR DESCRIPTION
UrlUtilService holds the base url pointing to the zuul gateway. If the gateway changes, only need to change this service.